### PR TITLE
Fix position_side tagging for full-close fills in fetch_pnls

### DIFF
--- a/src/exchanges/lighter.py
+++ b/src/exchanges/lighter.py
@@ -1935,14 +1935,16 @@ class LighterBot(Passivbot):
                         else:
                             computed_pnl = close_qty * (avg_entry - trade_price)
 
-                # Derive position_side from position state
+                # Derive position_side from position state.
+                # When a fill fully closes a position (pos_after == 0), the fill
+                # belongs to the side that was closed, so use pos_before's sign.
                 pos_after = pos_before + trade_delta
                 if pos_after > 0:
                     position_side = "long"
                 elif pos_after < 0:
                     position_side = "short"
                 else:
-                    position_side = "long" if trade_delta > 0 else "short"
+                    position_side = "long" if pos_before > 0 else "short"
 
                 pnls.append({
                     "id": trade_id,
@@ -1983,6 +1985,7 @@ class LighterBot(Passivbot):
                         if new_pos != 0.0:
                             avg_entry = total_cost / abs(new_pos)
 
+                    prev_net_pos = net_pos
                     net_pos = new_pos
                     p["pnl"] = computed_pnl
 
@@ -1991,7 +1994,7 @@ class LighterBot(Passivbot):
                     elif net_pos < 0:
                         p["position_side"] = "short"
                     else:
-                        p["position_side"] = "long" if trade_qty > 0 else "short"
+                        p["position_side"] = "long" if prev_net_pos > 0 else "short"
 
             return pnls
         except Exception as e:


### PR DESCRIPTION
## Summary

Fills that fully close a position were being tagged with the wrong `position_side` in both the main classifier and the reconstruction fallback of `fetch_pnls`. A sell-that-closes-a-long was recorded as `"short"`, and a buy-that-closes-a-short as `"long"`. The fix uses the sign of the pre-trade position instead of the trade delta so the fill is attributed to the side it actually belonged to.

## Impact

Downstream, `get_last_position_changes()` in `src/passivbot.py` scans `self.pnls` for the most recent fill matching `(symbol, position_side)` and feeds that timestamp into `update_trailing_data()`, which computes the trailing price bundle (`min_since_open` / `max_since_min` / …) from candles since that timestamp.

With close fills mis-tagged, the bot couldn't find a recent long-side change after a close-then-reopen cycle. The anchor fell back either to an older fill from a previous position's open, or to the 7-day default (`utc_ms() - 1000 * 60 * 60 * 24 * 7`). Over that window HYPE (and most coins) reliably have a dump-and-rebound pattern, which satisfies the trailing trigger conditions:

```
min_since_open < pprice * (1 - entry_trailing_threshold_pct)
AND
max_since_min  > min_since_open * (1 + entry_trailing_retracement_pct)
```

Result in live trading: an `entry_trailing_cropped_long` order was parked at `pprice * 0.9801` within seconds of every fresh position open, plus the grid ladder that the Rust orchestrator generates for anticipated post-trailing fills. Expected behavior (observed on the Hyperliquid sibling project running the same config) is for the bot to place no buy orders until an actual dump happens.

## Changes

`src/exchanges/lighter.py`:
- Main classifier (around line 1944): when `pos_after == 0`, tag with `"long" if pos_before > 0 else "short"`.
- Reconstruction fallback (around line 1994): capture `prev_net_pos` before `net_pos = new_pos`, then use `sign(prev_net_pos)` in the same branch.

This matches the semantics used by the Hyperliquid fill normalizer in the upstream project, which reads the exchange's `dir` field (`"Open Long"` / `"Close Long"` / …) directly so both the open buy and the close sell of a long are tagged `"long"`.

## Scenarios verified

| Fill | `pos_before` | `trade_delta` | `pos_after` | Before | After |
|---|---|---|---|---|---|
| Open long | 0 | +q | +q | long | long ✓ |
| Add to long | +p | +q | +p+q | long | long ✓ |
| Reduce long (partial) | +p | -q | +r>0 | long | long ✓ |
| **Close long fully** | **+p** | **-p** | **0** | **short** ❌ | **long** ✓ |
| Open short | 0 | -q | -q | short | short ✓ |
| Add to short | -p | -q | -(p+q) | short | short ✓ |
| Reduce short (partial) | -p | +q | -(p-q) | short | short ✓ |
| **Close short fully** | **-p** | **+p** | **0** | **long** ❌ | **short** ✓ |
| Flip long → short | +p | -(p+x) | -x | short | short (unchanged; pre-existing limitation) |
| Flip short → long | -p | +(p+x) | +x | long | long (unchanged; pre-existing limitation) |

The flip cases are a pre-existing single-record limitation and are not worsened by this patch.

## Deploy notes

The on-disk cache at `caches/{exchange}/{user}_pnls.json` persists pre-fix entries across restart, and `init_pnls()` de-duplicates new fills by `id` — so old mis-tagged rows are not re-tagged automatically. Operators should delete that file before the first restart with this fix applied:

```
rm caches/lighter/{user}_pnls.json
```

`init_pnls()` handles the missing file and will re-fetch `pnls_max_lookback_days` of trades from the exchange on startup.

## Test plan

- [ ] Delete `caches/lighter/{user}_pnls.json`, rebuild/restart container.
- [ ] First `[pos] new HYPE long ...` after restart should produce **only** the `close_grid_long` sell — no `entry_trailing_*` buy, no `entry_grid_*` buy, until WE ratio crosses `entry_trailing_grid_ratio` via actual fills.
- [ ] Shadow-mode `FillEventsManager` comparison logs (if `pnls_manager_shadow_mode` is enabled) should stop emitting `position_side mismatch` warnings for full-close fills.
- [ ] Close → reopen cycle: verify `get_last_position_changes` anchors to the close fill's timestamp, not a 7-day fallback, by cross-checking subsequent `update_trailing_data` candle-fetch windows in logs.